### PR TITLE
BSP2 Support

### DIFF
--- a/LibBSP/Source/Structs/BSP/BSP.cs
+++ b/LibBSP/Source/Structs/BSP/BSP.cs
@@ -53,6 +53,10 @@ namespace LibBSP
         /// Half-Life Blue Shift
         /// </summary>
         BlueShift = 0x01010001,
+        /// <summary>
+        /// Quake BSP2
+        /// </summary>
+        BSP2 = 0x01000001,
 
         /// <summary>
         /// Quake 2 or Quake 2 Engine flags, including <see cref="Daikatana"/> <see cref="SoF"/>

--- a/LibBSP/Source/Structs/BSP/BSPHeader.cs
+++ b/LibBSP/Source/Structs/BSP/BSPHeader.cs
@@ -9,7 +9,10 @@ namespace LibBSP
     /// </summary>
     public struct BSPHeader
     {
-
+        /// <summary>
+        /// "BSP2" represented as int32.
+        /// </summary>
+        public const int BSP2Header = 844124994;
         /// <summary>
         /// "IBSP" represented as int32.
         /// </summary>
@@ -421,7 +424,11 @@ namespace LibBSP
                 case MapType.Quake:
                 {
                     return BitConverter.GetBytes(29);
-                }
+                    }
+                case MapType.BSP2:
+                    {
+                        return BitConverter.GetBytes(BSP2Header);
+                    }
                 case MapType.GoldSrc:
                 case MapType.BlueShift:
                 {

--- a/LibBSP/Source/Structs/BSP/Edge.cs
+++ b/LibBSP/Source/Structs/BSP/Edge.cs
@@ -83,7 +83,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType == MapType.Vindictus)
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    return (int)BitConverter.ToUInt32(Data, 0);
+                }
+                else if (MapType == MapType.Vindictus)
                 {
                     return BitConverter.ToInt32(Data, 0);
                 }
@@ -99,8 +103,11 @@ namespace LibBSP
             set
             {
                 byte[] bytes = BitConverter.GetBytes(value);
-
-                if (MapType == MapType.Vindictus)
+				if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+					BitConverter.GetBytes((uint)value).CopyTo(Data, 0);
+                }
+				else if (MapType == MapType.Vindictus)
                 {
                     bytes.CopyTo(Data, 0);
                 }
@@ -132,7 +139,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType == MapType.Vindictus)
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    return (int)BitConverter.ToUInt32(Data, 4);
+                }
+                else if (MapType == MapType.Vindictus)
                 {
                     return BitConverter.ToInt32(Data, 4);
                 }
@@ -149,7 +160,11 @@ namespace LibBSP
             {
                 byte[] bytes = BitConverter.GetBytes(value);
 
-                if (MapType == MapType.Vindictus)
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+					BitConverter.GetBytes((uint)value).CopyTo(Data, 4);
+				}
+                else if (MapType == MapType.Vindictus)
                 {
                     BitConverter.GetBytes(value).CopyTo(Data, 4);
                 }
@@ -252,7 +267,11 @@ namespace LibBSP
         /// <exception cref="ArgumentException">This struct is not valid or is not implemented for the given <paramref name="mapType"/> and <paramref name="lumpVersion"/>.</exception>
         public static int GetStructLength(MapType mapType, int lumpVersion = 0)
         {
-            if (mapType == MapType.Vindictus)
+            if (mapType.IsSubtypeOf(MapType.BSP2))
+            {
+                return 8;
+            }
+            else if (mapType == MapType.Vindictus)
             {
                 return 8;
             }

--- a/LibBSP/Source/Structs/BSP/Face.cs
+++ b/LibBSP/Source/Structs/BSP/Face.cs
@@ -109,7 +109,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType == MapType.Nightfire
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    return BitConverter.ToInt32(Data, 0);
+                }
+                else if (MapType == MapType.Nightfire
                     || MapType == MapType.Vindictus)
                 {
                     return BitConverter.ToInt32(Data, 0);
@@ -128,14 +132,17 @@ namespace LibBSP
                 {
                     return BitConverter.ToUInt16(Data, 0);
                 }
-
                 return -1;
             }
             set
             {
                 byte[] bytes = BitConverter.GetBytes(value);
 
-                if (MapType == MapType.Nightfire
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+     				bytes.CopyTo(Data, 0);
+                }
+                else if (MapType == MapType.Nightfire
                     || MapType == MapType.Vindictus)
                 {
                     bytes.CopyTo(Data, 0);
@@ -167,8 +174,12 @@ namespace LibBSP
         {
             get
             {
-                if (MapType.IsSubtypeOf(MapType.Quake)
-                    || MapType.IsSubtypeOf(MapType.Quake2))
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    return BitConverter.ToUInt32(Data, 4) > 0;
+                }
+                else if (MapType.IsSubtypeOf(MapType.Quake)
+                   || MapType.IsSubtypeOf(MapType.Quake2))
                 {
                     return BitConverter.ToUInt16(Data, 2) > 0;
                 }
@@ -193,7 +204,11 @@ namespace LibBSP
             }
             set
             {
-                if (MapType == MapType.Vindictus)
+	            if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+    				BitConverter.GetBytes(value ? 1 : 0).CopyTo(Data, 4);
+                }
+				else if (MapType == MapType.Vindictus)
                 {
                     Data[4] = (byte)(value ? 1 : 0);
                 }
@@ -287,7 +302,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType == MapType.Source17)
+                if (MapType == MapType.BSP2)
+                {
+                    return BitConverter.ToInt32(Data, 8);
+                }
+                else if(MapType == MapType.Source17)
                 {
                     return BitConverter.ToInt32(Data, 36);
                 }
@@ -312,7 +331,11 @@ namespace LibBSP
             {
                 byte[] bytes = BitConverter.GetBytes(value);
 
-                if (MapType == MapType.Source17)
+				if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+					bytes.CopyTo(Data, 8);
+                }
+				else if (MapType == MapType.Source17)
                 {
                     bytes.CopyTo(Data, 36);
                 }
@@ -342,7 +365,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType == MapType.Source17)
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    return BitConverter.ToInt32(Data, 12);
+                }
+                else if (MapType == MapType.Source17)
                 {
                     return BitConverter.ToUInt16(Data, 40);
                 }
@@ -367,7 +394,11 @@ namespace LibBSP
             {
                 byte[] bytes = BitConverter.GetBytes(value);
 
-                if (MapType == MapType.Source17)
+				if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+    				bytes.CopyTo(Data, 12);
+                }
+				else if (MapType == MapType.Source17)
                 {
                     Data[40] = bytes[0];
                     Data[41] = bytes[1];
@@ -602,7 +633,7 @@ namespace LibBSP
         {
             get
             {
-                return Parent.Bsp.TextureInfo[TextureInfoIndex];
+				return Parent.Bsp.TextureInfo[TextureInfoIndex];
             }
         }
 
@@ -613,7 +644,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType == MapType.Nightfire)
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    return BitConverter.ToInt32(Data, 16);
+                }
+                else if (MapType == MapType.Nightfire)
                 {
                     return BitConverter.ToInt32(Data, 32);
                 }
@@ -634,14 +669,17 @@ namespace LibBSP
                 {
                     return BitConverter.ToUInt16(Data, 10);
                 }
-
                 return -1;
             }
             set
             {
                 byte[] bytes = BitConverter.GetBytes(value);
 
-                if (MapType == MapType.Nightfire)
+				if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+					bytes.CopyTo(Data, 16);
+                }
+				else if (MapType == MapType.Nightfire)
                 {
                     bytes.CopyTo(Data, 32);
                 }
@@ -1087,7 +1125,13 @@ namespace LibBSP
         {
             get
             {
-                if (MapType == MapType.SiN)
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    byte[] bytes = new byte[4];
+                    Array.Copy(Data, 20, bytes, 0, 4);
+                    return bytes;
+                }
+                else if(MapType == MapType.SiN)
                 {
                     byte[] bytes = new byte[16];
                     Array.Copy(Data, 12, bytes, 0, bytes.Length);
@@ -1148,7 +1192,12 @@ namespace LibBSP
             }
             set
             {
-                if (MapType == MapType.SiN)
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+    				Array.Copy(value, 0, Data, 20, Math.Min(value.Length, 4));
+                }
+				
+				else if (MapType == MapType.SiN)
                 {
                     Array.Copy(value, 0, Data, 12, Math.Min(value.Length, 16));
                 }
@@ -1248,7 +1297,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType == MapType.Raven)
+                if (MapType == MapType.BSP2)
+                {
+                    return BitConverter.ToInt32(Data, 24);
+                }
+                else if(MapType == MapType.Raven)
                 {
                     return BitConverter.ToInt32(Data, 36);
                 }
@@ -1301,7 +1354,12 @@ namespace LibBSP
             {
                 byte[] bytes = BitConverter.GetBytes(value);
 
-                if (MapType == MapType.Raven)
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+					bytes.CopyTo(Data, 24);
+                }
+				
+				else if (MapType == MapType.Raven)
                 {
                     bytes.CopyTo(Data, 36);
                 }
@@ -2188,7 +2246,11 @@ namespace LibBSP
         /// <exception cref="ArgumentException">This struct is not valid or is not implemented for the given <paramref name="mapType"/> and <paramref name="lumpVersion"/>.</exception>
         public static int GetStructLength(MapType mapType, int lumpVersion = 0)
         {
-            if (mapType == MapType.CoD4)
+            if (mapType.IsSubtypeOf(MapType.BSP2))
+            {
+                return 28;
+            }
+            else if(mapType == MapType.CoD4)
             {
                 return 24;
             }

--- a/LibBSP/Source/Structs/BSP/Leaf.cs
+++ b/LibBSP/Source/Structs/BSP/Leaf.cs
@@ -223,7 +223,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType == MapType.SoF)
+                if (MapType == MapType.BSP2)
+                {
+                    return new Vector3(BitConverter.ToSingle(Data, 8), BitConverter.ToSingle(Data, 12), BitConverter.ToSingle(Data, 16));
+                }
+                else if (MapType == MapType.SoF)
                 {
                     return new Vector3(BitConverter.ToInt16(Data, 10), BitConverter.ToInt16(Data, 12), BitConverter.ToInt16(Data, 14));
                 }
@@ -250,7 +254,13 @@ namespace LibBSP
             }
             set
             {
-                if (MapType == MapType.SoF)
+                if (MapType == MapType.BSP2)
+                {
+    				BitConverter.GetBytes((float)value.X()).CopyTo(Data, 8);
+    				BitConverter.GetBytes((float)value.Y()).CopyTo(Data, 12);
+    				BitConverter.GetBytes((float)value.Z()).CopyTo(Data, 16);
+                }
+                else if (MapType == MapType.SoF)
                 {
                     BitConverter.GetBytes((short)value.X()).CopyTo(Data, 10);
                     BitConverter.GetBytes((short)value.Y()).CopyTo(Data, 12);
@@ -290,7 +300,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType == MapType.SoF)
+                if (MapType == MapType.BSP2)
+                {
+                    return new Vector3(BitConverter.ToSingle(Data, 20), BitConverter.ToSingle(Data, 24), BitConverter.ToSingle(Data, 28));
+                }
+                else if (MapType == MapType.SoF)
                 {
                     return new Vector3(BitConverter.ToInt16(Data, 16), BitConverter.ToInt16(Data, 18), BitConverter.ToInt16(Data, 20));
                 }
@@ -317,7 +331,13 @@ namespace LibBSP
             }
             set
             {
-                if (MapType == MapType.SoF)
+                if (MapType == MapType.BSP2)
+                {
+				    BitConverter.GetBytes((float)value.X()).CopyTo(Data, 20);
+				    BitConverter.GetBytes((float)value.Y()).CopyTo(Data, 24);
+				    BitConverter.GetBytes((float)value.Z()).CopyTo(Data, 28);
+                }
+                else if (MapType == MapType.SoF)
                 {
                     BitConverter.GetBytes((short)value.X()).CopyTo(Data, 16);
                     BitConverter.GetBytes((short)value.Y()).CopyTo(Data, 18);
@@ -530,7 +550,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType == MapType.SoF)
+                if (MapType == MapType.BSP2)
+                {
+                    return (int)BitConverter.ToUInt32(Data, 32);
+                }
+                else if (MapType == MapType.SoF)
                 {
                     return BitConverter.ToUInt16(Data, 22);
                 }
@@ -556,7 +580,11 @@ namespace LibBSP
             {
                 byte[] bytes = BitConverter.GetBytes(value);
 
-                if (MapType == MapType.SoF)
+                if (MapType == MapType.BSP2)
+                {
+ 					BitConverter.GetBytes((uint)value).CopyTo(Data, 32);
+                }
+                else if (MapType == MapType.SoF)
                 {
                     Data[22] = bytes[0];
                     Data[23] = bytes[1];
@@ -588,7 +616,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType == MapType.SoF)
+                if (MapType == MapType.BSP2)
+                {
+                    return (int)BitConverter.ToUInt32(Data, 36);
+                }
+                else if (MapType == MapType.SoF)
                 {
                     return BitConverter.ToUInt16(Data, 24);
                 }
@@ -614,7 +646,11 @@ namespace LibBSP
             {
                 byte[] bytes = BitConverter.GetBytes(value);
 
-                if (MapType == MapType.SoF)
+                if (MapType == MapType.BSP2)
+                {
+					BitConverter.GetBytes((uint)value).CopyTo(Data, 36);
+                }
+                else if (MapType == MapType.SoF)
                 {
                     Data[24] = bytes[0];
                     Data[25] = bytes[1];
@@ -645,7 +681,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType.IsSubtypeOf(MapType.Quake))
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    return Data[40];
+                }
+                else if (MapType.IsSubtypeOf(MapType.Quake))
                 {
                     return Data[24];
                 }
@@ -654,7 +694,11 @@ namespace LibBSP
             }
             set
             {
-                if (MapType.IsSubtypeOf(MapType.Quake))
+                if (MapType == MapType.BSP2)
+                {
+                    Data[40] = value;
+                }
+                else if (MapType.IsSubtypeOf(MapType.Quake))
                 {
                     Data[24] = value;
                 }
@@ -668,7 +712,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType.IsSubtypeOf(MapType.Quake))
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    return Data[41];
+                }
+                else if (MapType.IsSubtypeOf(MapType.Quake))
                 {
                     return Data[25];
                 }
@@ -677,7 +725,11 @@ namespace LibBSP
             }
             set
             {
-                if (MapType.IsSubtypeOf(MapType.Quake))
+                if (MapType == MapType.BSP2)
+                {
+                   	Data[41] = value;
+                }
+                else if (MapType.IsSubtypeOf(MapType.Quake))
                 {
                     Data[25] = value;
                 }
@@ -691,7 +743,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType.IsSubtypeOf(MapType.Quake))
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    return Data[42];
+                }
+                else if (MapType.IsSubtypeOf(MapType.Quake))
                 {
                     return Data[26];
                 }
@@ -700,7 +756,11 @@ namespace LibBSP
             }
             set
             {
-                if (MapType.IsSubtypeOf(MapType.Quake))
+                if (MapType == MapType.BSP2)
+                {
+                   	Data[42] = value;
+                }
+                else if (MapType.IsSubtypeOf(MapType.Quake))
                 {
                     Data[26] = value;
                 }
@@ -714,7 +774,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType.IsSubtypeOf(MapType.Quake))
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    return Data[43];
+                }
+                else if (MapType.IsSubtypeOf(MapType.Quake))
                 {
                     return Data[27];
                 }
@@ -723,7 +787,11 @@ namespace LibBSP
             }
             set
             {
-                if (MapType.IsSubtypeOf(MapType.Quake))
+                if (MapType == MapType.BSP2)
+                {
+                   	Data[43] = value;
+                }
+                else if (MapType.IsSubtypeOf(MapType.Quake))
                 {
                     Data[27] = value;
                 }
@@ -975,7 +1043,11 @@ namespace LibBSP
         /// <exception cref="ArgumentException">This struct is not valid or is not implemented for the given <paramref name="mapType"/> and <paramref name="lumpVersion"/>.</exception>
         public static int GetStructLength(MapType mapType, int lumpVersion = 0)
         {
-            if (mapType == MapType.CoD4)
+            if (mapType == MapType.BSP2)
+            {
+                return 44;
+            }
+            else if (mapType == MapType.CoD4)
             {
                 return 24;
             }

--- a/LibBSP/Source/Structs/BSP/Node.cs
+++ b/LibBSP/Source/Structs/BSP/Node.cs
@@ -117,7 +117,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType.IsSubtypeOf(MapType.Quake))
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    return BitConverter.ToInt32(Data, 4);
+                }
+                else if (MapType.IsSubtypeOf(MapType.Quake))
                 {
                     return BitConverter.ToInt16(Data, 4);
                 }
@@ -135,7 +139,11 @@ namespace LibBSP
             {
                 byte[] bytes = BitConverter.GetBytes(value);
 
-                if (MapType.IsSubtypeOf(MapType.Quake))
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    bytes.CopyTo(Data, 4);
+                }
+				else if (MapType.IsSubtypeOf(MapType.Quake))
                 {
                     Data[4] = bytes[0];
                     Data[5] = bytes[1];
@@ -173,7 +181,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType.IsSubtypeOf(MapType.Quake))
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    return BitConverter.ToInt32(Data, 8);
+                }
+                else if (MapType.IsSubtypeOf(MapType.Quake))
                 {
                     return BitConverter.ToInt16(Data, 6);
                 }
@@ -191,7 +203,11 @@ namespace LibBSP
             {
                 byte[] bytes = BitConverter.GetBytes(value);
 
-                if (MapType.IsSubtypeOf(MapType.Quake))
+				if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+					bytes.CopyTo(Data, 8);
+                }
+				else if (MapType.IsSubtypeOf(MapType.Quake))
                 {
                     Data[6] = bytes[0];
                     Data[7] = bytes[1];
@@ -213,7 +229,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType.IsSubtypeOf(MapType.Quake))
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    return new Vector3(BitConverter.ToSingle(Data, 12), BitConverter.ToSingle(Data, 16), BitConverter.ToSingle(Data, 20));
+                }
+                else if(MapType.IsSubtypeOf(MapType.Quake))
                 {
                     return new Vector3(BitConverter.ToInt16(Data, 8), BitConverter.ToInt16(Data, 10), BitConverter.ToInt16(Data, 12));
                 }
@@ -231,12 +251,18 @@ namespace LibBSP
                 {
                     return Vector3Extensions.ToVector3(Data, 12);
                 }
-
+                
                 return new Vector3(0, 0, 0);
             }
             set
             {
-                if (MapType.IsSubtypeOf(MapType.Quake))
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    BitConverter.GetBytes((float)value.X()).CopyTo(Data, 12);
+				    BitConverter.GetBytes((float)value.Y()).CopyTo(Data, 16);
+				    BitConverter.GetBytes((float)value.Z()).CopyTo(Data, 20);
+                }
+				else if (MapType.IsSubtypeOf(MapType.Quake))
                 {
                     BitConverter.GetBytes((short)value.X()).CopyTo(Data, 8);
                     BitConverter.GetBytes((short)value.Y()).CopyTo(Data, 10);
@@ -270,7 +296,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType.IsSubtypeOf(MapType.Quake))
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    return new Vector3(BitConverter.ToSingle(Data, 24), BitConverter.ToSingle(Data, 28), BitConverter.ToSingle(Data, 32));
+                }
+                else if (MapType.IsSubtypeOf(MapType.Quake))
                 {
                     return new Vector3(BitConverter.ToInt16(Data, 14), BitConverter.ToInt16(Data, 16), BitConverter.ToInt16(Data, 18));
                 }
@@ -293,7 +323,13 @@ namespace LibBSP
             }
             set
             {
-                if (MapType.IsSubtypeOf(MapType.Quake))
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    BitConverter.GetBytes((float)value.X()).CopyTo(Data, 24);
+				    BitConverter.GetBytes((float)value.Y()).CopyTo(Data, 28);
+				    BitConverter.GetBytes((float)value.Z()).CopyTo(Data, 32);
+                }
+				else if (MapType.IsSubtypeOf(MapType.Quake))
                 {
                     BitConverter.GetBytes((short)value.X()).CopyTo(Data, 14);
                     BitConverter.GetBytes((short)value.Y()).CopyTo(Data, 16);
@@ -342,7 +378,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType.IsSubtypeOf(MapType.Quake))
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    return (int)BitConverter.ToUInt32(Data, 36);
+                }
+                else if (MapType.IsSubtypeOf(MapType.Quake))
                 {
                     return BitConverter.ToUInt16(Data, 20);
                 }
@@ -362,7 +402,11 @@ namespace LibBSP
             {
                 byte[] bytes = BitConverter.GetBytes(value);
 
-                if (MapType.IsSubtypeOf(MapType.Quake))
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    BitConverter.GetBytes((uint)value).CopyTo(Data, 36);
+                }
+				else if (MapType.IsSubtypeOf(MapType.Quake))
                 {
                     Data[20] = bytes[0];
                     Data[21] = bytes[1];
@@ -388,7 +432,11 @@ namespace LibBSP
         {
             get
             {
-                if (MapType.IsSubtypeOf(MapType.Quake))
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+                    return (int)BitConverter.ToUInt32(Data, 40);
+                }
+                else if (MapType.IsSubtypeOf(MapType.Quake))
                 {
                     return BitConverter.ToUInt16(Data, 22);
                 }
@@ -408,7 +456,11 @@ namespace LibBSP
             {
                 byte[] bytes = BitConverter.GetBytes(value);
 
-                if (MapType.IsSubtypeOf(MapType.Quake))
+                if (MapType.IsSubtypeOf(MapType.BSP2))
+                {
+					BitConverter.GetBytes((uint)value).CopyTo(Data, 40);
+                }
+				else if (MapType.IsSubtypeOf(MapType.Quake))
                 {
                     Data[22] = bytes[0];
                     Data[23] = bytes[1];
@@ -547,7 +599,11 @@ namespace LibBSP
         /// <exception cref="ArgumentException">This struct is not valid or is not implemented for the given <paramref name="mapType"/> and <paramref name="lumpVersion"/>.</exception>
         public static int GetStructLength(MapType mapType, int lumpVersion = 0)
         {
-            if (mapType.IsSubtypeOf(MapType.Quake))
+            if (mapType.IsSubtypeOf(MapType.BSP2))
+            {
+                return 44;
+            }
+            else if (mapType.IsSubtypeOf(MapType.Quake))
             {
                 return 24;
             }

--- a/LibBSP/Source/Structs/Common/Lumps/NumList.cs
+++ b/LibBSP/Source/Structs/Common/Lumps/NumList.cs
@@ -178,7 +178,12 @@ namespace LibBSP
         /// <returns>Index for this lump, or -1 if the format doesn't have this lump or it's not implemented.</returns>
         public static int GetIndexForLeafFacesLump(MapType version, out DataType dataType)
         {
-            if (version == MapType.Nightfire)
+            if (version == MapType.BSP2)
+            {
+                dataType = DataType.UInt32;
+                return 11;
+            }
+            else if (version == MapType.Nightfire)
             {
                 dataType = DataType.UInt32;
                 return 12;

--- a/LibBSP/Source/Util/BSPReader.cs
+++ b/LibBSP/Source/Util/BSPReader.cs
@@ -315,6 +315,11 @@ namespace LibBSP
                     }
                     switch (num)
                     {
+                        case BSPHeader.BSP2Header:
+                            {
+                                current = MapType.BSP2;
+                                break;
+                            }
                         case BSPHeader.IBSPHeader:
                         {
                             // Versions: CoD, CoD2, CoD4, Quake 2, Daikatana, Quake 3 (RtCW), Soldier of Fortune


### PR DESCRIPTION
This pull request adds BSP2 support.
BSP2 is an extension of the Quake BSP format with higher limits.

_Note: Some underlying data types in the BSP2 specification are defined as unsigned integers, while the corresponding property getters in LibBSP are defined as signed integers. In very rare cases where these values exceed the positive range of a UInt32, LibBSP may truncate the remaining data._

[https://quakewiki.org/wiki/BSP2](https://quakewiki.org/wiki/BSP2)
[https://forums.insideqc.com/viewtopic.php?t=501](https://forums.insideqc.com/viewtopic.php?t=5018)